### PR TITLE
Update for new SDKs

### DIFF
--- a/Settings-Stub/UltrasoundSettingsController.mm
+++ b/Settings-Stub/UltrasoundSettingsController.mm
@@ -24,11 +24,11 @@
 }
 
 - (void)getUltrasound {
-	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://repo.dynastic.co/package/ultrasound"]];
+	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://repo.dynastic.co/package/ultrasound"] options:@{} completionHandler:nil];
 }
 
 - (void)followOnTwitter {
-	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://twitter.com/intent/follow?screen_name=aydenpanhuyzen"]];
+	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://twitter.com/intent/follow?screen_name=aydenpanhuyzen"] options:@{} completionHandler:nil];
 }
 
 @end


### PR DESCRIPTION
'openURL:' has been deprecated in iOS 10.0 - 'openURL:options:completionHandler:' should be used instead